### PR TITLE
Fix: Handle Infinity and initial operator input

### DIFF
--- a/script.js
+++ b/script.js
@@ -41,7 +41,7 @@ function insertNumber(num) {
  * @param {string} operator - The operator input (one of CalculatorSystem.CalculatorOperation or CalculatorSystem.CalculatorOperationUI).
  */
 function insertOperator(operator) {
-    if (calculatorMemory.firstNumber == Infinity.toString() && operator != "CLEAR") return;
+    if (calculatorMemory.firstNumber == Infinity.toString() && operator !== "CLEAR") return;
     if (operator == CalculatorSystem.CalculatorOperation.EQUAL && calculatorMemory.operation == CalculatorSystem.CalculatorOperation.EQUAL) return;
     switch (operator) {
         case CalculatorSystem.CalculatorOperation.EQUAL:


### PR DESCRIPTION
When Infinity is displayed, and a number is pressed, reset the calculator state. Also, prevent setting an operator if Infinity is displayed, unless it's the CLEAR operator.
Close #1 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents invalid operations when the display shows Infinity by blocking operator input until cleared or a new number is entered.
  * Allows seamless entry of a new number after Infinity, resetting the main and operator displays appropriately.
  * Improves handling of pending operations to avoid propagating an invalid state after overflow/Infinity.
  * Ensures clearer state transitions when switching or clearing operations following an Infinity result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->