### PR TITLE
Format large numbers in display

### DIFF
--- a/script.js
+++ b/script.js
@@ -80,7 +80,12 @@ function insertOperator(operator) {
  * @param {string} numberStr - The number text to render on the display; may be empty or falsy to reset to "0".
  */
 function setDisplayNumber(numberStr) {
-    displayComponent.textContent = numberStr || 0;
+    if (numberStr && numberStr.indexOf('.') >= 0 && numberStr.indexOf('.') < numberStr.length - 4) {
+        displayComponent.textContent = (+numberStr).toFixed(3);
+    } else {
+        displayComponent.textContent = numberStr || 0;
+    }
+
 }
 
 /**

--- a/script.js
+++ b/script.js
@@ -80,7 +80,8 @@ function insertOperator(operator) {
  * @param {string} numberStr - The number text to render on the display; may be empty or falsy to reset to "0".
  */
 function setDisplayNumber(numberStr) {
-    if (numberStr && numberStr.indexOf('.') >= 0 && numberStr.indexOf('.') < numberStr.length - 4) {
+    const decimalIndex = numberStr ? numberStr.indexOf('.') : -1;
+    if (decimalIndex >= 0 && decimalIndex < numberStr.length - 4) {
         displayComponent.textContent = (+numberStr).toFixed(3);
     } else {
         displayComponent.textContent = numberStr || 0;


### PR DESCRIPTION
Limit displayed numbers to 3 decimal places to prevent overflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Numbers with four or more digits after the decimal are now automatically rounded to three decimal places for display, improving readability.
  * Shorter decimals and integer values display unchanged.
  * Empty or falsy inputs now display as “0” to ensure consistent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->